### PR TITLE
Make script changes to support openshift

### DIFF
--- a/manifests/kruize.yaml_template
+++ b/manifests/kruize.yaml_template
@@ -36,12 +36,6 @@ spec:
         ports:
         - name: http
           containerPort: 31313
-      nodeSelector:
-        node-role.kubernetes.io/master: 'true'
-      tolerations:
-      - key: "dedicated"
-        operator: "Exists"
-        effect: "NoSchedule"
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/servicemonitor/kruize-service-monitor.yaml
+++ b/manifests/servicemonitor/kruize-service-monitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   name: kruize
   labels:
-    team: frontend
+    team: kruize-frontend
 spec:
   selector:
     matchLabels:
@@ -19,7 +19,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorSelector:
     matchLabels:
-      team: frontend
+      team: kruize-frontend
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
Closes #5 
1. Removed nodeSelector and tolerations from template yaml
2. Renamed minikube manifest folder to serviceMonitor
3. Modified script to apply serviceMonitor for openshift

Signed-off-by: Shishir Halaharvi <shihala1@in.ibm.com>