### PR TITLE
build.sh should take image name as a parameter.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,12 +24,18 @@ function usage() {
 }
 
 # Check error code from last command, exit on error
-check_err() {
+function check_err() {
 	err=$?
 	if [ ${err} -ne 0 ]; then
 		echo "$*"
 		exit -1
 	fi
+}
+
+# Remove any previous images of kruize
+function cleanup() {
+	docker rmi $(docker images | grep kruize | awk '{ print $3 }') >/dev/null 2>/dev/null
+	docker rmi $(docker images | grep kruize | awk '{ printf "%s:%s\n", $1, $2 }') >/dev/null 2>/dev/null
 }
 
 # Iterate through the commandline options
@@ -48,6 +54,7 @@ do
 done
 
 git pull
+cleanup
 
 DOCKER_REPO=$(echo ${KRUIZE_DOCKER_IMAGE} | awk -F":" '{ print $1 }')
 DOCKER_TAG=$(echo ${KRUIZE_DOCKER_IMAGE} | awk -F":" '{ print $2 }')

--- a/manifests/kruize.yaml_template
+++ b/manifests/kruize.yaml_template
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kruize-sa
       containers:
       - name: kruize
-        image: dinogun/kruize:{{ KRUIZE_VERSION }}
+        image: {{ KRUIZE_DOCKER_IMAGE }}
         imagePullPolicy: Always
         env:
         - name: CLUSTER_TYPE

--- a/scripts/icp-helpers.sh
+++ b/scripts/icp-helpers.sh
@@ -70,7 +70,7 @@ function icp_setup() {
 	sleep 1
 
 	sed "s/{{ K8S_TYPE }}/ICP/" ${DEPLOY_TEMPLATE} > ${DEPLOY_MANIFEST}
-	sed -i "s/{{ KRUIZE_VERSION }}/${KRUIZE_VERSION}/" ${DEPLOY_MANIFEST}
+	sed -i "s/{{ KRUIZE_DOCKER_IMAGE }}/${KRUIZE_DOCKER_IMAGE}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ BEARER_AUTH_TOKEN }}/${br_token}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ MONITORING_SERVICE }}/${pservice}/" ${DEPLOY_MANIFEST}
 	sed -i "s|{{ MONITORING_AGENT_ENDPOINT }}|${purl}|" ${DEPLOY_MANIFEST}

--- a/scripts/minikube-helpers.sh
+++ b/scripts/minikube-helpers.sh
@@ -105,7 +105,7 @@ function minikube_setup() {
 
 	sed "s|extensions/v1beta1|apps/v1|" ${DEPLOY_TEMPLATE} > ${DEPLOY_MANIFEST}
 	sed -i "s/replicas: 1/replicas: 1\n  selector:\n    matchLabels:\n      app: kruize/" ${DEPLOY_MANIFEST}
-	sed -i "s/{{ KRUIZE_VERSION }}/${KRUIZE_VERSION}/" ${DEPLOY_MANIFEST}
+	sed -i "s/{{ KRUIZE_DOCKER_IMAGE }}/${KRUIZE_DOCKER_IMAGE}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ K8S_TYPE }}/Minikube/" ${DEPLOY_TEMPLATE} ${DEPLOY_MANIFEST}
 	sed -i "s/{{ BEARER_AUTH_TOKEN }}/${br_token}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ MONITORING_SERVICE }}/${pservice}/" ${DEPLOY_MANIFEST}

--- a/scripts/openshift-helpers.sh
+++ b/scripts/openshift-helpers.sh
@@ -69,7 +69,7 @@ function openshift_setup() {
 	sleep 1
 
 	sed "s/{{ K8S_TYPE }}/OpenShift/" ${DEPLOY_TEMPLATE} > ${DEPLOY_MANIFEST}
-	sed -i "s/{{ KRUIZE_VERSION }}/${KRUIZE_VERSION}/" ${DEPLOY_MANIFEST}
+	sed -i "s/{{ KRUIZE_DOCKER_IMAGE }}/${KRUIZE_DOCKER_IMAGE}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ BEARER_AUTH_TOKEN }}/${br_token}/" ${DEPLOY_MANIFEST}
 	sed -i "s/{{ MONITORING_SERVICE }}/${pservice}/" ${DEPLOY_MANIFEST}
 	sed -i "s|{{ MONITORING_AGENT_ENDPOINT }}|${purl}|" ${DEPLOY_MANIFEST}


### PR DESCRIPTION
Fail build.sh on docker build failure.
Cleanup any previous docker images of kruize.
deploy.sh should use image name parameter for all k8s deployments.
Fixes #57 

Signed-off-by: Dinakar Guniguntala dinakar.g@in.ibm.com