### PR TITLE
Set multi-release to true in maven.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                         </manifest>
                         <manifestEntries>
                             <Main-Class>com.kruize.main.Kruize</Main-Class>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
This ensures Log4j will not fallback to the getCallerClass()
methods, and ensure better performance.

Fixes #80 

Signed-off-by: Shishir Halaharvi <shihala1@in.ibm.com>