### PR TITLE
Fix original limits being exported in MB

### DIFF
--- a/src/main/java/com/kruize/environment/docker/DockerEnvImpl.java
+++ b/src/main/java/com/kruize/environment/docker/DockerEnvImpl.java
@@ -256,7 +256,7 @@ public class DockerEnvImpl extends EnvTypeImpl
         }
 
         if (container.getAsJsonObject().has("cpu_limit")) {
-            containerMetrics.setOriginalMemoryLimit(container.getAsJsonObject().get("cpu_limit").getAsDouble());
+            containerMetrics.setOriginalCpuLimit(container.getAsJsonObject().get("cpu_limit").getAsDouble());
         }
 
         for (String runtime : applicationRecommendations.runtimesMap.keySet())

--- a/src/main/java/com/kruize/environment/kubernetes/KubernetesEnvImpl.java
+++ b/src/main/java/com/kruize/environment/kubernetes/KubernetesEnvImpl.java
@@ -378,8 +378,9 @@ public class KubernetesEnvImpl extends EnvTypeImpl
         if (podRequests != null) {
             if (podRequests.containsKey("memory")) {
                 Quantity memoryRequests = (Quantity) podRequests.get("memory");
-                double memoryRequestsValue = MathUtil.bytesToMB(memoryRequests.getNumber().doubleValue());
-                LOGGER.debug("Original memory requests for {}: {} MB", applicationName, memoryRequestsValue);
+                double memoryRequestsValue = memoryRequests.getNumber().doubleValue();
+                LOGGER.debug("Original memory requests for {}: {} MB", applicationName,
+                        MathUtil.bytesToMB(memoryRequestsValue));
 
                 metrics.setOriginalMemoryRequests(memoryRequestsValue);
             }
@@ -397,8 +398,9 @@ public class KubernetesEnvImpl extends EnvTypeImpl
         if (podLimits != null) {
             if (podLimits.containsKey("memory")) {
                 Quantity memoryLimit = (Quantity) podLimits.get("memory");
-                double memoryLimitValue = MathUtil.bytesToMB(memoryLimit.getNumber().doubleValue());
-                LOGGER.debug("Original memory limit for {}: {} MB", applicationName, memoryLimitValue);
+                double memoryLimitValue = memoryLimit.getNumber().doubleValue();
+                LOGGER.debug("Original memory limit for {}: {} MB", applicationName,
+                        MathUtil.bytesToMB(memoryLimitValue));
 
                 metrics.setOriginalMemoryLimit(memoryLimitValue);
             }

--- a/src/main/java/com/kruize/service/RecommendationsService.java
+++ b/src/main/java/com/kruize/service/RecommendationsService.java
@@ -98,7 +98,9 @@ public class RecommendationsService extends HttpServlet
                 try {
                     JsonObject applicationRecommendationJson = getApplicationJson(applicationRecommendations,
                             application);
-                    jsonArray.add(applicationRecommendationJson);
+                    if (applicationRecommendationJson != null) {
+                        jsonArray.add(applicationRecommendationJson);
+                    }
                 } catch (NoSuchApplicationException e) {
                     System.out.println(application + " not found");
 
@@ -239,8 +241,13 @@ public class RecommendationsService extends HttpServlet
 
         String gcPolicyRecommendation = javaRecommendations.getGcPolicy();
 
-        String percentage = precisionTwo.format((heapRecommendations * 100)
-                /  applicationRecommendations.getRssLimits(application));
+        String percentage = "0";
+        double rssLimits = applicationRecommendations.getRssLimits(application);
+
+        if (rssLimits != 0) {
+            percentage = precisionTwo.format((heapRecommendations * 100)
+                    / rssLimits);
+        }
 
         JsonObject runtimeRecommendationJson = new JsonObject();
         runtimeRecommendationJson.addProperty("name", "JAVA_TOOL_OPTIONS");


### PR DESCRIPTION
Fixes #151 

In the recent change, all values were being saved in MB. However, the Kruize grafana dashboard expects values in bytes. Reverting back the change to MB for original limits and requests.

Also added a couple of null checks.

Signed-off-by: Shishir Halaharvi <shihala1@in.ibm.com>